### PR TITLE
NetworkRequestHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.3.61'
     repositories {
         mavenCentral()
         google()
@@ -11,6 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3'

--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'jacoco-android'
-//apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'com.github.kt3k.coveralls'
 
 group = 'com.github.Wolox'
 
@@ -33,9 +33,9 @@ jacocoAndroidUnitTestReport {
 }
 
 
-//coveralls {
-//    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReleaseUnitTestReport/jacocoTestReleaseUnitTestReport.xml"
-//}
+coveralls {
+    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReleaseUnitTestReport/jacocoTestReleaseUnitTestReport.xml"
+}
 
 buildscript {
     ext.wolmo_version = '4.0.0'

--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     api "joda-time:joda-time:$joda_version"
     api "com.google.code.findbugs:jsr305:$findbugs_version"
 
+    kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
+
     // Test
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.mockito:mockito-inline:$mockito_inline_version" // Mockito inline adds support for mocking final classes and methods

--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -1,4 +1,7 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'jacoco-android'
 apply plugin: 'com.github.kt3k.coveralls'
 
@@ -35,13 +38,13 @@ coveralls {
 
 buildscript {
     ext.wolmo_version = '4.0.0'
-    ext.retrofit_version = '2.7.0'
+    ext.retrofit_version = '2.9.0'
     ext.okhttp3_version = '3.9.0'
     ext.dagger_version = '2.25.3'
     ext.joda_version = '2.10'
     ext.findbugs_version = '3.0.2'
     ext.junit_version = '4.12'
-    ext.mockito_inline_version = '2.13.0'
+    ext.mockito_inline_version = '2.19.0'
     ext.assertj_version = '3.9.0'
 }
 

--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'jacoco-android'
-apply plugin: 'com.github.kt3k.coveralls'
+//apply plugin: 'com.github.kt3k.coveralls'
 
 group = 'com.github.Wolox'
 
@@ -32,9 +32,10 @@ jacocoAndroidUnitTestReport {
     excludes = defaultExcludes + ['**/*_Factory.class']
 }
 
-coveralls {
-    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReleaseUnitTestReport/jacocoTestReleaseUnitTestReport.xml"
-}
+
+//coveralls {
+//    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReleaseUnitTestReport/jacocoTestReleaseUnitTestReport.xml"
+//}
 
 buildscript {
     ext.wolmo_version = '4.0.0'

--- a/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/callback/NetworkCallback.java
+++ b/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/callback/NetworkCallback.java
@@ -107,12 +107,12 @@ public abstract class NetworkCallback<T> implements Callback<T> {
      */
     public abstract void onResponseFailed(@Nullable ResponseBody responseBody, int code);
 
-        /**
-         * The HTTP request to the server failed on the local device, no data was transmitted.
-         * Invoked when a network or unexpected exception occurred during the HTTP request, meaning
-         * that the request couldn't be executed.
-         *
-         * @param t A Throwable with the cause of the call failure
-         */
+    /**
+     * The HTTP request to the server failed on the local device, no data was transmitted.
+     * Invoked when a network or unexpected exception occurred during the HTTP request, meaning
+     * that the request couldn't be executed.
+     *
+     * @param t A Throwable with the cause of the call failure
+     */
     public abstract void onCallFailure(Throwable t);
 }

--- a/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/callback/NetworkCallback.java
+++ b/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/callback/NetworkCallback.java
@@ -107,12 +107,12 @@ public abstract class NetworkCallback<T> implements Callback<T> {
      */
     public abstract void onResponseFailed(@Nullable ResponseBody responseBody, int code);
 
-    /**
-     * The HTTP request to the server failed on the local device, no data was transmitted.
-     * Invoked when a network or unexpected exception occurred during the HTTP request, meaning
-     * that the request couldn't be executed.
-     *
-     * @param t A Throwable with the cause of the call failure
-     */
+        /**
+         * The HTTP request to the server failed on the local device, no data was transmitted.
+         * Invoked when a network or unexpected exception occurred during the HTTP request, meaning
+         * that the request couldn't be executed.
+         *
+         * @param t A Throwable with the cause of the call failure
+         */
     public abstract void onCallFailure(Throwable t);
 }

--- a/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandler.kt
+++ b/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandler.kt
@@ -1,0 +1,24 @@
+package ar.com.wolox.wolmo.networking.retrofit.handler
+
+import retrofit2.Response
+
+object NetworkRequestHandler {
+
+    suspend fun <T : Response<*>> safeApiCall(block: suspend () -> T): NetworkResponse<T> =
+            try {
+                val response = block.invoke()
+                if (response.isSuccessful) {
+                    NetworkResponse.Success(response)
+                } else {
+                    NetworkResponse.Error(response)
+                }
+            } catch (t: Throwable) {
+                NetworkResponse.Failure(t)
+            }
+}
+
+sealed class NetworkResponse<T> {
+    data class Success<T>(val body: T) : NetworkResponse<T>()
+    data class Error<T>(val body: T) : NetworkResponse<T>()
+    data class Failure<T>(val t: Throwable) : NetworkResponse<T>()
+}

--- a/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandler.kt
+++ b/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandler.kt
@@ -5,16 +5,13 @@ import retrofit2.Response
 /**
  * An adapter that converts Retrofit's responses to other, more specific, ones
  * depending on network status codes or failures when using Kotlin's Coroutines.
- *
- * @param <T> the type of object expected to be returned from the API call
+ * It will return a [NetworkResponse] object indicating operation result.
  */
 object NetworkRequestHandler {
 
     /**
-     * Static method that allows to execute requests and returns a NetworkResponse object {@link NetworkResponse}
-     * depending on HTTP response
-     *
-     * @param block is a suspend function of Response<T> type
+     * Static method that allows to execute requests from a [suspend] function of [Response] type
+     * and returns a [NetworkResponse] object depending on HTTP response.
      */
     suspend fun <T : Response<*>> safeApiCall(block: suspend () -> T): NetworkResponse<T> =
             try {
@@ -34,27 +31,24 @@ sealed class NetworkResponse<T> {
     /**
      * Successful HTTP response from the server.
      * The server received the request, answered it and the response is not of an error type.
-     *
-     * @param response the API JSON response converted to a Java/Kotlin object.
-     * The API response code is included in the response object.
+     * It will return a [T] object, the API JSON response converted to a Java/Kotlin object,
+     * which includes the API response code.
      */
     data class Success<T>(val response: T) : NetworkResponse<T>()
 
     /**
      * Successful HTTP response from the server, but has an error body.
      * The server received the request, answered it and reported an error.
-     *
-     * @param response the API JSON response converted to a Java/Kotlin object.
-     * The API response code is included in the response object.
+     * It will return a [T], the API JSON response converted to a Java/Kotlin object,
+     * which includes the API response code.
      */
     data class Error<T>(val response: T) : NetworkResponse<T>()
 
     /**
      * The HTTP request to the server failed on the local device, no data was transmitted.
      * Invoked when a network or unexpected exception occurred during the HTTP request, meaning
-     * that the request couldn't be executed.
-     *
-     * @param t A Throwable with the cause of the call failure
+     * that the request couldn't be executed. The cause of the failure will be given through a
+     * [Throwable] object
      */
     data class Failure<T>(val t: Throwable) : NetworkResponse<T>()
 }

--- a/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandler.kt
+++ b/networking/src/main/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandler.kt
@@ -2,8 +2,20 @@ package ar.com.wolox.wolmo.networking.retrofit.handler
 
 import retrofit2.Response
 
+/**
+ * An adapter that converts Retrofit's responses to other, more specific, ones
+ * depending on network status codes or failures when using Kotlin's Coroutines.
+ *
+ * @param <T> the type of object expected to be returned from the API call
+ */
 object NetworkRequestHandler {
 
+    /**
+     * Static method that allows to execute requests and returns a NetworkResponse object {@link NetworkResponse}
+     * depending on HTTP response
+     *
+     * @param block is a suspend function of Response<T> type
+     */
     suspend fun <T : Response<*>> safeApiCall(block: suspend () -> T): NetworkResponse<T> =
             try {
                 val response = block.invoke()
@@ -18,7 +30,31 @@ object NetworkRequestHandler {
 }
 
 sealed class NetworkResponse<T> {
-    data class Success<T>(val body: T) : NetworkResponse<T>()
-    data class Error<T>(val body: T) : NetworkResponse<T>()
+
+    /**
+     * Successful HTTP response from the server.
+     * The server received the request, answered it and the response is not of an error type.
+     *
+     * @param response the API JSON response converted to a Java/Kotlin object.
+     * The API response code is included in the response object.
+     */
+    data class Success<T>(val response: T) : NetworkResponse<T>()
+
+    /**
+     * Successful HTTP response from the server, but has an error body.
+     * The server received the request, answered it and reported an error.
+     *
+     * @param response the API JSON response converted to a Java/Kotlin object.
+     * The API response code is included in the response object.
+     */
+    data class Error<T>(val response: T) : NetworkResponse<T>()
+
+    /**
+     * The HTTP request to the server failed on the local device, no data was transmitted.
+     * Invoked when a network or unexpected exception occurred during the HTTP request, meaning
+     * that the request couldn't be executed.
+     *
+     * @param t A Throwable with the cause of the call failure
+     */
     data class Failure<T>(val t: Throwable) : NetworkResponse<T>()
 }

--- a/networking/src/test/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandlerTest.kt
+++ b/networking/src/test/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandlerTest.kt
@@ -1,0 +1,58 @@
+package ar.com.wolox.wolmo.networking.retrofit.handler
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.MockitoAnnotations
+import org.mockito.stubbing.Answer
+import retrofit2.Response
+
+@ExperimentalCoroutinesApi
+class NetworkRequestHandlerTest {
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    fun `given a succesfull response with code between 200 and 300, NetworkResponse Success state is called`() = runBlocking {
+        // GIVEN
+        val apiResponse = mock(Response::class.java) as Response<Any>
+
+
+        // WHEN
+        `when`(apiResponse.isSuccessful).thenReturn(true)
+
+        // THEN
+        val networkResponse = NetworkRequestHandler.safeApiCall { apiResponse }
+        assert(networkResponse is NetworkResponse.Success)
+    }
+
+    @Test
+    fun `given a succesfull response with code above 300, NetworkResponse Error state is called`() = runBlocking {
+        // GIVEN
+        val apiResponse = mock(Response::class.java) as Response<Any>
+
+        // WHEN
+        `when`(apiResponse.isSuccessful).thenReturn(false)
+
+        // THEN
+        val networkResponse = NetworkRequestHandler.safeApiCall { apiResponse }
+        assert(networkResponse is NetworkResponse.Error)
+    }
+
+    @Test
+    fun `given a non-succesfull response, NetworkResponse Failure state is called`() = runBlocking {
+        // GIVEN
+        val answer: Answer<Exception> = Answer { Exception() }
+        val apiResponse = mock (Response::class.java, answer) as Response<Any>
+
+        // THEN
+        val networkResponse = NetworkRequestHandler.safeApiCall { apiResponse }
+        assert(networkResponse is NetworkResponse.Failure)
+    }
+}

--- a/networking/src/test/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandlerTest.kt
+++ b/networking/src/test/java/ar/com/wolox/wolmo/networking/retrofit/handler/NetworkRequestHandlerTest.kt
@@ -23,7 +23,6 @@ class NetworkRequestHandlerTest {
         // GIVEN
         val apiResponse = mock(Response::class.java) as Response<Any>
 
-
         // WHEN
         `when`(apiResponse.isSuccessful).thenReturn(true)
 


### PR DESCRIPTION
### Summary
- `NetworkRequestHandler` was created. It helps to filter HTTP responses into `NetworkResponse` objects when using Retrofit with Kotlin's Coroutines.
- `NetworkResponse` is a sealed class with three different `data` classes:
                - Success: Will be called when request is successful status code is between 200 and 300
                - Error: Will be called when request is done successfully but it's status code is above 300 
                - Failure: Will be called when request fails. It will return a `Throwable` to catch failure reason.